### PR TITLE
Properly load values for Hooks

### DIFF
--- a/static/js/comp/type/base.js
+++ b/static/js/comp/type/base.js
@@ -430,12 +430,14 @@ Formbuilder.comp.type.base = Class.create({
                 {
                     xtype: "textfield",
                     name: "custom_class",
+                    value: this.datax.custom_class,
                     fieldLabel: t("custom class"),
                     anchor: "100%"
                 },
                 {
                     xtype: "textfield",
                     name: "custom_action",
+                    value: this.datax.custom_action,
                     fieldLabel: t("static action"),
                     anchor: "100%"
                 }


### PR DESCRIPTION
When editing field the methos and class name currently get lost because they are not populated back into the ExtJS form.